### PR TITLE
#79 getUserStudyGroups now returns an array of studyGroups

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -1,4 +1,5 @@
 import User from '../models/user';
+import StudyGroup from '../models/studyGroup';
 import cuid from 'cuid';
 import sha512 from 'sha512';
 import sanitizeHtml from 'sanitize-html';
@@ -77,7 +78,7 @@ export function updateUser(req, res) {
   User.findOneAndUpdate({ cuid: req.params.cuid }, { $set: update }, function (err, updated) {
     if (err) {
       return res.status(500).send(err);
-    } 
+    }
     else {
       return res.json({ user: updated });
     }
@@ -111,8 +112,14 @@ export function getUserStudyGroups(req, res) {
     if (err) {
       return res.status(500).send(err);
     }
-    return res.json({ studyGroups });
-  });
+    console.log(studyGroups)
+    StudyGroup.find({ guid: {$in: studyGroups.studyGroups }}).exec((err, foundGroups) => {
+      if (err) {
+        return res.status(500).send(err);
+      }
+        return res.json({ myGroups: foundGroups });
+      });
+    });
 }
 
 export function addUserStudyGroups(req, res) {


### PR DESCRIPTION
### Description
The `getUserStudyGroups` now returns an array of objects with all the study groups of a specific user.

### How to use it
use the GET endpoint `/api/users/:cuid/studyGroups` and concatenate the **user cuid** to the URL.

ex:
```
export function fetchUserGroups(cuid) {
const URL = `user/${cuid}/studyGroups`
  return (dispatch) => {
    return callApi(URL)
    .then(res => dispatch(getUserStudyGroups(res.myGroups)));
  };
```
}
 