### PR TITLE
#124 Users cannot enter non numeric characters in studentId anymore

### DIFF
--- a/client/modules/User/components/FormComponents/Validator.js
+++ b/client/modules/User/components/FormComponents/Validator.js
@@ -37,7 +37,7 @@ Object.assign(Validation.rules, {
   studentId: {
 
     rule: value => {
-      const re = /[0-9]{8}/;
+      const re = /^[0-9]{8}$/;
 
       return re.test(value);
     },


### PR DESCRIPTION
Added delimiters to the student Id regex to prevent non-valid studentIds