### PR TITLE
fix #131 and fix #76 added new message filtering

### DIFF
--- a/client/modules/User/UserReducer.js
+++ b/client/modules/User/UserReducer.js
@@ -97,12 +97,14 @@ const UserReducer = (state = initialState, action) => {
     }
     case PREPARE_CHAT_MESSAGE: {
       let userIndex = state.chat.users.indexOf(action.message.user);
+
       if (userIndex === -1) {
         state.chat.users.push(action.message.user);
         userIndex = state.chat.users.length - 1;
       }
 
       state.chat.messages.push(<div key={state.chat.messages.length + 1} style={{ color: getColorFromUserIndex(userIndex) }}>{`${action.message.user}: ${action.message.message}`}</div>);
+      
       return {
         user: state.user,
         currentStudyGroup: state.currentStudyGroup,

--- a/client/modules/User/components/ChatComponent/ChatComponent.js
+++ b/client/modules/User/components/ChatComponent/ChatComponent.js
@@ -49,7 +49,9 @@ export class ChatComponent extends Component {
   }
 
   onMessageReceive(data) {
-    this.props.prepareChatMessage(data);
+    if (this.props.users.user.studyGroups[this.props.users.currentStudyGroup].guid == data.studyGroup) {
+      this.props.prepareChatMessage(data);      
+    }
   }
 
   handleChange(event) {

--- a/server/socketEvents.js
+++ b/server/socketEvents.js
@@ -31,7 +31,7 @@ exports = module.exports = function (io) {
           throw err;
         }
         else {
-          io.sockets.emit('UpdateMessages', { message: data.message, user: socket.nickname });
+          io.sockets.emit('UpdateMessages', { message: data.message, user: socket.nickname, studyGroup: data.studyGroup });
         }
       });
     });


### PR DESCRIPTION
### Description
Added filtering when a user sends a new message in a study group chat. The new message will only display for other users if they have the same study group chat open.

### Breakdown
- Added a new argument in the 'UpdateMessages' socket event to pass the study group guid back to the front end.
- Added a condition to filter the need to update the currently opened chat with a new message

### Testing
- Tested locally with two different users (on different browsers) sending messages in groups they share